### PR TITLE
Feat: Add GPT-4o model (with caveats)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ you can set their paths and filenames via `HEY_CONFIG_PATH`, `HEY_CONFIG_FILENAM
 
 ## config file reference
 ```toml
-model = "Claude" # or "GPT3"
+model = "Claude" # or "GPT4OMini"
 tos = false # whether if you agree to ddg chat tos
 ```
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -77,10 +77,5 @@ impl Cache {
 
     pub fn get_last_vqd<'a, T: From<&'a String>>(self: &'a Self) -> Option<T> {
         None
-        /*if self.last_vqd_time - (chrono::Local::now().timestamp_millis() as u64) < 60000 {
-            Some((&self.last_vqd).into())
-        } else {
-            None
-        } */
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -76,10 +76,11 @@ impl Cache {
     }
 
     pub fn get_last_vqd<'a, T: From<&'a String>>(self: &'a Self) -> Option<T> {
-        if self.last_vqd_time - (chrono::Local::now().timestamp_millis() as u64) < 60000 {
+        None
+        /*if self.last_vqd_time - (chrono::Local::now().timestamp_millis() as u64) < 60000 {
             Some((&self.last_vqd).into())
         } else {
             None
-        }
+        } */
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl ToString for Model {
             Self::GPT3 => String::from("gpt-3.5-turbo-0125"),
             Self::Llama => String::from("meta-llama/Llama-3-70b-chat-hf"),
             Self::Mixtral => String::from("mistralai/Mixtral-8x7B-Instruct-v0.1"),
-            Self::GPT4OMini => String::from("gpt-4-0125-preview")
+            Self::GPT4OMini => String::from("gpt-4o-mini")
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,13 +8,13 @@ pub enum Model {
     // outdated
     Claude12,
     GPT35,
+    GPT3,
 
     // current
     Claude,
-    GPT3,
+    GPT4OMini,
     Llama,
-    Mixtral,
-    GPT4OMini
+    Mixtral
 }
 
 impl ToString for Model {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,8 @@ pub enum Model {
     Claude,
     GPT3,
     Llama,
-    Mixtral
+    Mixtral,
+    GPT4OMini
 }
 
 impl ToString for Model {
@@ -25,7 +26,8 @@ impl ToString for Model {
             Self::Claude => String::from("claude-3-haiku-20240307"),
             Self::GPT3 => String::from("gpt-3.5-turbo-0125"),
             Self::Llama => String::from("meta-llama/Llama-3-70b-chat-hf"),
-            Self::Mixtral => String::from("mistralai/Mixtral-8x7B-Instruct-v0.1")
+            Self::Mixtral => String::from("mistralai/Mixtral-8x7B-Instruct-v0.1"),
+            Self::GPT4OMini => String::from("gpt-4-0125-preview")
         }
     }
 }


### PR DESCRIPTION
This PR adds the `gpt-4o-mini` model, which can be set with the string `GPT4OMini` in the config.

```toml
model = "GPT4OMini"
```

I also made a change to disable the vqd caching and retrieval functionality. It seems DuckDuckGo have changed something on their backend, which causes errors with the newer model. This change doesn't seem to effect any of the model outputs, I may just be misunderstanding something so please do take a look.

```rust
    pub fn get_last_vqd<'a, T: From<&'a String>>(self: &'a Self) -> Option<T> {
        None
        /*if self.last_vqd_time - (chrono::Local::now().timestamp_millis() as u64) < 60000 {
            Some((&self.last_vqd).into())
        } else {
            None
        } */
    }
```